### PR TITLE
fixed sros prompt starting with asterisk

### DIFF
--- a/docs/changelog/undistributed.rst
+++ b/docs/changelog/undistributed.rst
@@ -1,3 +1,6 @@
 Features and Bug Fixes:
 ^^^^^^^^^^^^^^^^^^^^^^^
 
+- sros plugin
+
+  - Updated prompt pattern to expect prompts starting with ``*``.

--- a/src/unicon/plugins/sros/patterns.py
+++ b/src/unicon/plugins/sros/patterns.py
@@ -10,5 +10,5 @@ class SrosPatterns(UniconCorePatterns):
         self.continue_connect = r'Are you sure you want to continue connecting \(yes/no\)'
         self.permission_denied = r'^Permission denied, please try again\.\s?$'
         self.mdcli_prompt = r'^(.*)\[.*\][\r\n]+A:.*@%N#\s?$'
-        self.classiccli_prompt = r'^A:%N(>.*)?#\s?$'
+        self.classiccli_prompt = r'^\*?A:%N(>.*)?#\s?$'
         self.discard_uncommitted = 'Discard uncommitted changes\? \[y,n\]'


### PR DESCRIPTION
Related to : https://github.com/CiscoTestAutomation/pyats/issues/40