### PR TITLE
fixed timeout for configure in doc

### DIFF
--- a/docs/user_guide/services/generic_services.rst
+++ b/docs/user_guide/services/generic_services.rst
@@ -269,7 +269,7 @@ on prompt_recovery feature.
 ====================  =======================    ========================================
 Argument              Type                       Description
 ====================  =======================    ========================================
-timeout               int (default 60 sec)       timeout value for the command execution takes.
+timeout               int                        timeout value for the command execution takes.
 error_pattern         list                       List of regex strings to check output for errors.
 append_error_pattern  list                        List of regex strings append to error_pattern.
 reply                 Dialog                     additional dialog

--- a/docs/user_guide/services/staros.rst
+++ b/docs/user_guide/services/staros.rst
@@ -61,7 +61,7 @@ Use `prompt_recovery` argument for using `prompt_recovery` feature.
 ===============   ======================    ========================================
 Argument          Type                      Description
 ===============   ======================    ========================================
-timeout           int (default 60 sec)      timeout value for the command execution takes.
+timeout           int (default 30 sec)      timeout value for the command execution takes.
 reply             Dialog                    additional dialog
 command           str or list               string or list of commands to configure
 prompt_recovery   bool (default False)      Enable/Disable prompt recovery feature


### PR DESCRIPTION
removed default timeout from configure service. it's actually 30 secs default globally. but it depends on plugin since some of plugins overwrite it. so removed to avoid confusion.

For StarOS, based on code, it should be 30 secs. so fixed.