### PR TITLE
plugin: add support for drivenets/dnos + fix: nokia/sros prompt when mdcli is used

### DIFF
--- a/src/unicon/plugins/__init__.py
+++ b/src/unicon/plugins/__init__.py
@@ -38,6 +38,7 @@ supported_os = [
     'slxos',
     'nd',
     'viptela',
+    'dnos',
     'dnos6',
     'dnos10',
     'ons',

--- a/src/unicon/plugins/dnos/__init__.py
+++ b/src/unicon/plugins/dnos/__init__.py
@@ -1,0 +1,55 @@
+'''
+Unicon Plugin Example Implementation
+------------------------------------
+
+In this example, we will implement a sample Unicon connection plugin supporting
+the DRIVENETS platform named "dnos" by inheriting from the built-in Unicon
+Base connection plugin.
+
+Note:
+    Make sure the content of this file contains the Connection subclass
+    this plugin implements. 
+
+'''
+
+# import the base dependencies
+# (extending built-in plugins)
+
+from unicon.bases.routers.connection import BaseSingleRpConnection
+from unicon.plugins.generic import GenericSingleRpConnectionProvider
+from unicon.plugins.dnos.statemachine import DnosSingleRpStateMachine
+from unicon.plugins.dnos.services import DnosServiceList
+from unicon.plugins.dnos.settings import DnosSettings
+
+
+class DnosSingleRPConnection(BaseSingleRpConnection):
+    '''DnosSingleRPConnection
+    
+    DRIVENETS dnos platform support. 
+    '''
+
+    # each connection plugin needs to declare the os it supports
+    os = 'dnos'
+
+    # there's no specific series in this platform
+    # set it to None to indicate so
+    series = None
+
+    # single-rp chasis or dual-rp chasis
+    chassis_type = 'single_rp'
+
+    # each connection class must be accompanied by its own state machine class
+    # a state machine class provides the connection implementation the means of
+    # recognizing the current state the device is in, all available subsequent
+    # states, and how to switch between states. (eg, from exec -> config)
+    state_machine_class = DnosSingleRpStateMachine
+    connection_provider_class = GenericSingleRpConnectionProvider
+
+    # all subcommands (eg, connection methods) are called services, and are
+    # listed under the ServiceList class. The ServiceList class aggregates all
+    # services (classes) that implements the actual methods into one top-level
+    # location, to be managed by the connection class.
+    subcommand_list = DnosServiceList
+
+    # any key/value setting pairs goes here
+    settings = DnosSettings()

--- a/src/unicon/plugins/dnos/patterns.py
+++ b/src/unicon/plugins/dnos/patterns.py
@@ -1,0 +1,28 @@
+'''
+Unicon Plugin Patterns
+----------------------
+
+Pattern module in a Unicon plugin allows developers to consolidate all
+regex patterns that matches dialogs, statements & the likes into one location.
+
+'''
+
+unicon.plugin.generic.patterns import GenericPatterns
+
+
+class DnosPatterns(GenericPatterns):
+
+    """
+        Class defines all the patterns required
+        for dnos
+    """
+    def __init__(self):
+        super().__init__()
+        self.continue_connect = r'Are you sure you want to continue connecting \(yes/no(/\[fingerprint\])?\)\s*$'
+        self.permission_denied = r'^(.*?)Permission denied(.*?)$'
+        # thishostname# 
+        self.operation_prompt = r'^(.*?)[\r\n]%N#\s?$'
+        # thishostname(cfg-if-bundle-10)# 
+        self.configuration_prompt = r'^(.*?)%N\(cfg[-\w]*\)#\s?$'
+        # Warning: Configuration includes uncommitted changes, would you like to commit them before exiting (yes/no/cancel) [cancel]? 
+        self.commit_changes_prompt = r'^Warning: Configuration includes uncommitted changes, would you like to commit them before exiting \(yes/no/cancel\) \[cancel\]?\s*$'

--- a/src/unicon/plugins/dnos/services.py
+++ b/src/unicon/plugins/dnos/services.py
@@ -1,0 +1,43 @@
+'''
+Unicon Plugin Service
+---------------------
+
+Each method under a Unicon connection is modelled as a "service". Services must
+inherit from the BaseService class, and implement call_service() method, which
+acts as the entrypoint to when a service is called.
+
+After services are defined, they should be aggregated together under a 
+ServiceList class as attributes.
+'''
+import logging
+
+from unicon.bases.routers.services import BaseService
+from unicon.plugins.generic import ServiceList
+from unicon.plugins.generic.service_implementation import (Execute as GenericExecute,
+                                                           Configure as GenericConfigure)
+
+
+logger = logging.getLogger(__name__)
+
+class Execute(GenericExecute):
+    '''
+    Demonstrating how to augment an existing service by updating its call
+    service method
+
+    '''
+    def call_service(self, *args, **kwargs):
+        # call parent
+        super().call_service(*args, **kwargs)
+
+
+class DnosServiceList(ServiceList):
+    '''
+    class aggregating all service lists for this platform
+    '''
+
+    def __init__(self):
+        # use the parent services
+        super().__init__()
+        # overwrite and add our own
+        self.execute = Execute
+        

--- a/src/unicon/plugins/dnos/settings.py
+++ b/src/unicon/plugins/dnos/settings.py
@@ -1,0 +1,25 @@
+'''
+Connection Settings
+-------------------
+
+Connection settings are basically various key/value pairs that controls the
+default behavior of a connection. 
+
+'''
+
+from unicon.plugins.generic.settings import GenericSettings
+
+
+class DnosSettings(GenericSettings):
+ 
+    def __init__(self):
+        # inherit any parent settings
+        super().__init__()
+
+        # and modify some for our own
+        self.CONNECTION_TIMEOUT = 60*3
+        self.HA_INIT_EXEC_COMMANDS = []
+        self.HA_INIT_CONFIG_COMMANDS = []
+
+        # and we could add more - to be used in plugins if needed
+        # self.<keyword> = <value>

--- a/src/unicon/plugins/dnos/statemachine.py
+++ b/src/unicon/plugins/dnos/statemachine.py
@@ -1,0 +1,31 @@
+'''
+Connection Statemachine
+-----------------------
+
+The connection state machine holds the details of all supported states of a 
+given platform, and handles the migration of the device from current state to
+any possible next state.
+
+The state machineclass provides a create method where all the device states 
+have to be created. State machine should be subclass of StateMachine class 
+from unicon.statemachine.
+'''
+
+from unicon.statemachine import State, Path, StateMachine
+# from unicon.eal.dialogs import Statement, Dialog
+from unicon.plugins.dnos.patterns import DnosPatterns
+
+
+pat = DnosPatterns()
+
+
+class DnosSingleRpStateMachine(StateMachine):
+
+    def create(self):
+        '''
+        statemachine class's create() method is its entrypoint. This showcases
+        how to setup a statemachine in Unicon. 
+        '''
+        enable = State('enable', pat.operation_prompt)
+        self.add_state(enable)
+        

--- a/src/unicon/plugins/sros/patterns.py
+++ b/src/unicon/plugins/sros/patterns.py
@@ -9,6 +9,6 @@ class SrosPatterns(UniconCorePatterns):
         super().__init__()
         self.continue_connect = r'Are you sure you want to continue connecting \(yes/no(/\[fingerprint\])?\)'
         self.permission_denied = r'^Permission denied, please try again\.\s?$'
-        self.mdcli_prompt = r'^(.*?)\[.*\][\r\n]+[AB]:.*@%N[#$]\s?$'
+        self.mdcli_prompt = r'^(.*?)(\[/?\]|\[(ex|gl|pr|ro):/?configure\])[\r\n]+[AB]:.*@%N#\s?$'
         self.classiccli_prompt = r'^(.*?)\*?[AB]:%N(>.*)?[#$]\s?$'
         self.discard_uncommitted = r'Discard uncommitted changes\? \[y,n\]'


### PR DESCRIPTION
Hi,

* nokia/sros & mdcli

**PROBLEM**: unicon fails to .execute the admin show configuration | no-more command in case of a nokia/sros router when using the mdcli mode.

**REASON**: This is happening because in mdcli you can configure regex expressions that use square brackets. Currently, the square brackets are tied to the prompt definition, hence the reason that unicon is failing to save the router's configuration.

* drivenets/dnos

**PROBLEM**: there is no support for the drivenets/dnos cli.

**REASON**: This PR is based on the proposed (base/generic) plugin implementation and it works against the drivenets/dnos cli.